### PR TITLE
Remove 'eligible' from footer text

### DIFF
--- a/about.html
+++ b/about.html
@@ -104,7 +104,7 @@
             <div class="footer__grid">
                 <div>
                     <h3 class="footer__title">Georgia Connects</h3>
-                    <p>Helping eligible households access affordable connectivity solutions.</p>
+                    <p>Helping households access affordable connectivity solutions.</p>
                 </div>
                 <div>
                     <h3 class="footer__title">Quick Links</h3>

--- a/contact.html
+++ b/contact.html
@@ -95,7 +95,7 @@
             <div class="footer__grid">
                 <div>
                     <h3 class="footer__title">Georgia Connects</h3>
-                    <p>Helping eligible households access affordable connectivity solutions.</p>
+                    <p>Helping households access affordable connectivity solutions.</p>
                 </div>
                 <div>
                     <h3 class="footer__title">Quick Links</h3>

--- a/data.html
+++ b/data.html
@@ -230,7 +230,7 @@
             <div class="footer__grid">
                 <div>
                     <h3 class="footer__title">Georgia Connects</h3>
-                    <p>Helping eligible households access affordable connectivity solutions.</p>
+                    <p>Helping households access affordable connectivity solutions.</p>
                 </div>
                 <div>
                     <h3 class="footer__title">Quick Links</h3>

--- a/index.html
+++ b/index.html
@@ -76,7 +76,7 @@
             <div class="footer__grid">
                 <div>
                     <h3 class="footer__title">Georgia Connects</h3>
-                    <p>Helping eligible households access affordable connectivity solutions.</p>
+                    <p>Helping households access affordable connectivity solutions.</p>
                 </div>
                 <div>
                     <h3 class="footer__title">Quick Links</h3>

--- a/news.html
+++ b/news.html
@@ -60,7 +60,7 @@
             <div class="footer__grid">
                 <div>
                     <h3 class="footer__title">Georgia Connects</h3>
-                    <p>Helping eligible households access affordable connectivity solutions.</p>
+                    <p>Helping households access affordable connectivity solutions.</p>
                 </div>
                 <div>
                     <h3 class="footer__title">Quick Links</h3>


### PR DESCRIPTION
This PR removes the word 'eligible' from the footer text across all pages to make the messaging more inclusive.