### PR TITLE
Remove support email and phone numbers

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -56,15 +56,10 @@
                     <h3 style="font-size: var(--font-size-xl); margin-bottom: var(--spacing-md);">Email Us</h3>
                     <p style="margin-bottom: var(--spacing-sm);">For general inquiries:</p>
                     <p><a href="mailto:gaconnectsyou@gmail.com" style="color: var(--color-primary); text-decoration: none;">gaconnectsyou@gmail.com</a></p>
-                    <p style="margin-top: var(--spacing-md);">For support:</p>
-                    <p><a href="mailto:support@lifelineconnect.org" style="color: var(--color-primary); text-decoration: none;">support@lifelineconnect.org</a></p>
                 </div>
                 <div class="card">
-                    <h3 style="font-size: var(--font-size-xl); margin-bottom: var(--spacing-md);">Call Us</h3>
-                    <p style="margin-bottom: var(--spacing-sm);">Main Office:</p>
-                    <p><a href="tel:+15551234567" style="color: var(--color-primary); text-decoration: none;">(555) 123-4567</a></p>
-                    <p style="margin-top: var(--spacing-md);">Support Line:</p>
-                    <p><a href="tel:+15551234568" style="color: var(--color-primary); text-decoration: none;">(555) 123-4568</a></p>
+                    <h3 style="font-size: var(--font-size-xl); margin-bottom: var(--spacing-md);">Hours</h3>
+                    <p>Monday - Friday: 9:00 AM - 5:00 PM</p>
                 </div>
             </div>
         </section>


### PR DESCRIPTION
Removed support email address and phone numbers from contact page. Changes include: - Removed support email (support@lifelineconnect.org) - Removed entire Call Us section with phone numbers - Added Hours section to maintain layout