### PR TITLE
Fix: Add getPreferences method to StateManager

### DIFF
--- a/js/state-manager.js
+++ b/js/state-manager.js
@@ -128,6 +128,14 @@ class StateManager {
     }
 
     /**
+     * Get the preferences object
+     * @returns {Object} Preferences state
+     */
+    getPreferences() {
+        return this.state.preferences;
+    }
+
+    /**
      * Update priorities based on selected preferences
      */
     updatePriorities() {


### PR DESCRIPTION
This PR fixes an issue where the Next button on the interview page was not working. The getPreferences method was missing in the StateManager class, causing a validation error.